### PR TITLE
updates to supported PAS+OpsMan versions

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -44,15 +44,15 @@ The following table provides version and version-support information about Dynat
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v2.2.x, v2.3.x, v2.4.x, and v2.5.x</td>
+        <td>v2.6.x, v2.5.x, v2.4.x, v2.3.x, and v2.2.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service version(s)</td>
-        <td>v2.2.x, v2.3.x, v2.4.x, and v2.5.x</td>
+        <td>v2.6.x, v2.5.x, v2.4.x, v2.3.x, and v2.2.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Container Service version(s)</td>
-        <td>v1.2.x, 1.3.x, and 1.4.x</td>
+        <td>v1.4.x, 1.3.x, and 1.2.x</td>
     </tr>
 </table>
 


### PR DESCRIPTION
- re-ordered versions to descending order to match pivnet
- added 2.6.x to supported versions

Note: Dynatrace continues to support the addon against 2.2.x until Aug-2019 which is why you still see it on the list: https://www.dynatrace.com/support/help/technology-support/cloud-platforms/cloud-foundry/capabilities-and-supported-versions/dynatrace-support-model-for-pivotal-cloud-foundry/