### PR TITLE
Add information about no other addons.

### DIFF
--- a/docs-content/uninstalling.html.md.erb
+++ b/docs-content/uninstalling.html.md.erb
@@ -24,6 +24,11 @@ addons:
 ...
   </pre>
 
+If no other addons are defined, use an empty array.
+  <pre>
+  addons: []
+  </pre>
+
 1. Update the runtime config.
   <pre class="terminal">
     $ bosh -e my-env update-runtime-config PATH\_TO\_SAVE\_THE\_RUNTIME\_CONFIG


### PR DESCRIPTION
The updater will complain when addons is defined previously and addons is removed.  Using an empty array will prevent the update from failing.